### PR TITLE
@Builder @NO or AllArgsConstructor @Entitiry 관계 정리 및 불필요한 어노테이션 제거 및 필요한 어노테이션 추가 

### DIFF
--- a/src/main/java/backend/codebackend/domain/Account.java
+++ b/src/main/java/backend/codebackend/domain/Account.java
@@ -1,25 +1,24 @@
 package backend.codebackend.domain;
 
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
-@NoArgsConstructor
 @Getter
 @Setter
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "account_tb", indexes = {
         @Index(name = "idx_account_number", columnList = "number")
 })
-@Entity
-@Builder
+
 public class Account {
 
     @Id
@@ -45,17 +44,4 @@ public class Account {
 
     private int is_paid;          // 결제
     private int complete_payment; // 결제 완료(결제 후)
-
-    public Account(Long id, String account_name, String number, String password, Long balance, String username, LocalDateTime create_at, LocalDateTime update_at, int is_paid, int complete_payment) {
-        this.id = id;
-        this.account_name = account_name;
-        this.number = number;
-        this.password = password;
-        this.balance = balance;
-        this.username = username;
-        this.create_at = create_at;
-        this.update_at = update_at;
-        this.is_paid = is_paid;
-        this.complete_payment = complete_payment;
-    }
 }

--- a/src/main/java/backend/codebackend/domain/Basket.java
+++ b/src/main/java/backend/codebackend/domain/Basket.java
@@ -1,10 +1,7 @@
 package backend.codebackend.domain;
 
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -17,8 +14,9 @@ import java.util.List;
 @Getter
 @Setter
 @Builder
-@NoArgsConstructor
 @Entity
+@NoArgsConstructor
+@AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 public class Basket {
 
@@ -41,15 +39,4 @@ public class Basket {
     @LastModifiedDate
     @Column(nullable = false)
     private LocalDateTime updated_at;
-
-    public Basket(Long id, Long chatroom_id, String product_name, int price, int quantity, String nickname, LocalDateTime created_at, LocalDateTime updated_at) {
-        this.id = id;
-        this.chatroom_id = chatroom_id;
-        this.product_name = product_name;
-        this.price = price;
-        this.quantity = quantity;
-        this.nickname = nickname;
-        this.created_at = created_at;
-        this.updated_at = updated_at;
-    }
 }

--- a/src/main/java/backend/codebackend/domain/Chat.java
+++ b/src/main/java/backend/codebackend/domain/Chat.java
@@ -10,12 +10,13 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
-@Data
 @Getter
+@Setter
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class Chat {
     //메시지 타입 : 입장, 채팅
     //메시지 타입에 따라서 동작하는 구조가 달라진ㄷ
@@ -48,16 +49,4 @@ public class Chat {
     private String filename; // 파일이름
     @Column(nullable = true)
     private String filedir; // s3 파일 경로
-
-    public Chat(String type, String chatId, Long id, String sender, String message, LocalDateTime createdAt, String s3_data_url, String filename, String filedir) {
-        this.type = type;
-        this.chatId = chatId;
-        this.id = id;
-        this.sender = sender;
-        this.message = message;
-        this.createdAt = createdAt;
-        this.s3_data_url = s3_data_url;
-        this.filename = filename;
-        this.filedir = filedir;
-    }
 }

--- a/src/main/java/backend/codebackend/domain/ChatUser.java
+++ b/src/main/java/backend/codebackend/domain/ChatUser.java
@@ -7,23 +7,17 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 //채팅방 id에 해당하는 유저를 저장하는 테이블
 @Getter
-@Data
+@Setter
 @Entity
-@EntityListeners(AuditingEntityListener.class)
-@NoArgsConstructor
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class ChatUser {
-
     @Id
     private Long id;
 
     @Column(length = 10, nullable = false)
     private String nickname;
     private int host;    // 방장
-
-    public ChatUser(Long id, String nickname, int host) {
-        this.id = id;
-        this.nickname = nickname;
-        this.host = host;
-    }
 }

--- a/src/main/java/backend/codebackend/domain/Member.java
+++ b/src/main/java/backend/codebackend/domain/Member.java
@@ -2,23 +2,15 @@ package backend.codebackend.domain;
 
 
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
+import lombok.*;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
-@Entity
-@NoArgsConstructor //기본 생성자를 추가해주는 어노테이션
-@Builder
 @Getter
 @Setter
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Member {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY) //DB가 ID를 자동으로 생성해 주는 전략 : IDENTITY
     private Long id;
@@ -43,23 +35,4 @@ public class Member {
 
     @Column(length = 17, nullable = false)
     private String certified;
-
-//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
-//    private List<Basket> baskets;
-//
-//    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL)
-//    private ChatUser chatUser;
-
-
-    public Member(Long id, String login, String pw, String pwcheck, String username, String nickname, String address, String pnum, String certified) {
-        this.id = id;
-        this.login = login;
-        this.pw = pw;
-        this.pwcheck = pwcheck;
-        this.username = username;
-        this.nickname = nickname;
-        this.address = address;
-        this.pnum = pnum;
-        this.certified = certified;
-    }
 }

--- a/src/main/java/backend/codebackend/domain/Menu.java
+++ b/src/main/java/backend/codebackend/domain/Menu.java
@@ -1,14 +1,14 @@
 package backend.codebackend.domain;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.List;
 
 @Getter
 @Setter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Menu {
     private String menuName;
     private String menuPrice;
@@ -18,15 +18,4 @@ public class Menu {
     private String minPrice;
     private List<List<Menu>> menuList_Title;
     private List<String> menuList_Title_Name;
-
-    public Menu(String menuName, String menuPrice, String menuDesc, String menuPhoto, String delivery_fee, String minPrice, List<List<Menu>> menuList_Title, List<String> menuList_Title_Name) {
-        this.menuName = menuName;
-        this.menuPrice = menuPrice;
-        this.menuDesc = menuDesc;
-        this.menuPhoto = menuPhoto;
-        this.delivery_fee = delivery_fee;
-        this.minPrice = minPrice;
-        this.menuList_Title = menuList_Title;
-        this.menuList_Title_Name = menuList_Title_Name;
-    }
 }

--- a/src/main/java/backend/codebackend/domain/Mozip.java
+++ b/src/main/java/backend/codebackend/domain/Mozip.java
@@ -2,21 +2,17 @@ package backend.codebackend.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
-import lombok.extern.java.Log;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.List;
 
 @Getter
+@Setter
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
 @Builder
-@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class Mozip {
     public enum mozipStatus {
         정산전, 정산시작, 거래확정, 결제완료;
@@ -55,17 +51,4 @@ public class Mozip {
 
     @Column(length = 20, nullable = false)
     private String nickname;
-
-    public Mozip(Long id, String title, Long distance_limit, String categories, String store, int usercount, int peoples, mozipStatus status, LocalDateTime create_Date, String nickname) {
-        this.id = id;
-        this.title = title;
-        this.distance_limit = distance_limit;
-        this.categories = categories;
-        this.store = store;
-        this.usercount = usercount;
-        this.peoples = peoples;
-        this.status = status;
-        this.create_Date = create_Date;
-        this.nickname = nickname;
-    }
 }

--- a/src/main/java/backend/codebackend/domain/PaymentDetails.java
+++ b/src/main/java/backend/codebackend/domain/PaymentDetails.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 @Entity
 @Builder
 @NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "payment")
 public class PaymentDetails {
     public enum PaymentStatus{
@@ -48,17 +49,5 @@ public class PaymentDetails {
     @PrePersist // JPA가 엔티티를 데이터베이스 처음 저장할 때 호출
     public void prePersist() {
         this.createdAt = LocalDateTime.now();
-    }
-
-    public PaymentDetails(Long paymentId, Member member, Mozip mozip, String nickname, String orderList, int totalPrice, PaymentStatus payStatus, LocalDateTime createdAt, String deliveryAddress) {
-        this.paymentId = paymentId;
-        this.member = member;
-        this.mozip = mozip;
-        this.nickname = nickname;
-        this.orderList = orderList;
-        this.totalPrice = totalPrice;
-        this.payStatus = payStatus;
-        this.createdAt = createdAt;
-        this.deliveryAddress = deliveryAddress;
     }
 }

--- a/src/main/java/backend/codebackend/domain/Restuarant.java
+++ b/src/main/java/backend/codebackend/domain/Restuarant.java
@@ -1,12 +1,12 @@
 package backend.codebackend.domain;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
-@Builder
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Restuarant {
     private String title;
     private String minPrice;
@@ -14,13 +14,4 @@ public class Restuarant {
     private String deliveryTime;
     private String icoStar;
     private String review_num;
-
-    public Restuarant(String title, String minPrice, String imageUrl, String deliveryTime, String icoStar, String review_num) {
-        this.title = title;
-        this.minPrice = minPrice;
-        this.imageUrl = imageUrl;
-        this.deliveryTime = deliveryTime;
-        this.icoStar = icoStar;
-        this.review_num = review_num;
-    }
 }

--- a/src/main/java/backend/codebackend/dto/AccountDto.java
+++ b/src/main/java/backend/codebackend/dto/AccountDto.java
@@ -3,9 +3,7 @@ package backend.codebackend.dto;
 import backend.codebackend.domain.Member;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
@@ -29,15 +27,4 @@ public class AccountDto {
     private LocalDateTime createAt;
     @LastModifiedDate
     private LocalDateTime updateAt;
-
-    public AccountDto(Long id, String number, String password, Long balance, String username, String account_name, LocalDateTime createAt, LocalDateTime updateAt) {
-        this.id = id;
-        this.number = number;
-        this.password = password;
-        this.balance = balance;
-        this.username = username;
-        this.account_name = account_name;
-        this.createAt = createAt;
-        this.updateAt = updateAt;
-    }
 }

--- a/src/main/java/backend/codebackend/dto/ChatDTO.java
+++ b/src/main/java/backend/codebackend/dto/ChatDTO.java
@@ -1,16 +1,12 @@
 package backend.codebackend.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Data
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor
 public class ChatDTO {
     //메시지 타입 : 입장, 채팅
     //메시지 타입에 따라서 동작하는 구조가 달라진ㄷ

--- a/src/main/java/backend/codebackend/dto/FileUploadDto.java
+++ b/src/main/java/backend/codebackend/dto/FileUploadDto.java
@@ -1,13 +1,10 @@
 package backend.codebackend.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
-@AllArgsConstructor
-@NoArgsConstructor
+
 @Data
 @Builder
 public class FileUploadDto {

--- a/src/main/java/backend/codebackend/dto/MemberForm.java
+++ b/src/main/java/backend/codebackend/dto/MemberForm.java
@@ -37,17 +37,6 @@ public class MemberForm {
     @NotEmpty(message = "공백을 포함해선 안됩니다.")
     private String certified;
 
-    public MemberForm(String login, String pw, String pwcheck, String username, String nickname, String address, String pnum, String certified) {
-        this.login = login;
-        this.pw = pw;
-        this.pwcheck = pwcheck;
-        this.username = username;
-        this.nickname = nickname;
-        this.address = address;
-        this.pnum = pnum;
-        this.certified = certified;
-    }
-
     public Member toEntity(){
         Member member = Member.builder()
                 .login(login)

--- a/src/main/java/backend/codebackend/dto/TotalPrice.java
+++ b/src/main/java/backend/codebackend/dto/TotalPrice.java
@@ -1,21 +1,12 @@
 package backend.codebackend.dto;
 
-import lombok.Builder;
-import lombok.Data;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 
 @Getter
-@Data
-@NoArgsConstructor
+@Setter
 @Builder
 public class TotalPrice {
     private String username;
     private int totalPrice;
-
-    public TotalPrice(String username, int totalPrice) {
-        this.username = username;
-        this.totalPrice = totalPrice;
-    }
 }


### PR DESCRIPTION
`@Builder`, `@Entity`, `@NoArgsConstructor` 조합.
위에서 하나라또 빠지면 오류가 생긴다.
[이유]

1. `@Builder`에서는 모든 필드를 받는 생성자가 필요하다. 그래서 이를 자동으로 만들어줌.

2. 그런데 `@Entity` 는 JPA에서 리플렉션을 사용할때 기본 생성자가 필요함. 근데 `@Builder`가 매개변수를 갖는 생성자를 생성해버리니 기본 생성자가 자동으로 생성이 안됨(자바 클래스에서 매개변수를 가진 생성자 생성 시 기본 생성자 자동 호출이 안되는 원리)
3. 따라서 죽음의 이지선다에 걸려버림
   - 직접 기본 생성자를 작성하거나
   - `@AllArgsConstructor` + `@AllArgsConstructor` 선언